### PR TITLE
Bug 22: Fix Schema Result column name mismatch

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
@@ -78,7 +78,7 @@
                         document.getElementById("clear_below").value = config.clear_below;
                         document.getElementById("clear_threshold").value = config.clear_threshold;
                         document.getElementById("collections_flag").value = config.collections_flag;
-                        document.getElementById("processing_debit").value = config.debit_type;
+                        document.getElementById("processing_debit").value = config.config_debit_type;
                         document.getElementById("run_on_dow").value = config.day_of_week;
                         document.getElementById("config-enabled").value = config.enabled;
                         document.getElementById("exemption_flag").value = config.exemptions_flag;
@@ -345,7 +345,7 @@
                     config_name: $('#config_name').val(),
                     config_type: configtype,
                     day_of_week: $('#run_on_dow').val(),
-                    debit_type: debit_type,
+                    config_debit_type: debit_type,
                     enabled: $('#config-enabled').val(),
                     exemptions_flag: $('#exemption_flag').val(),
                     fees_newer: $('#fees_starting_age').val(),

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
@@ -197,7 +197,7 @@ If there is a default configuration, all branches/groups will be included. 0=dis
 
 Options are global (can only have 1 global), branch, or group
 
-=head2 debit_type
+=head2 config_debit_type
 
   data_type: 'varchar'
   is_nullable: 0
@@ -249,8 +249,6 @@ __PACKAGE__->add_columns(
   { data_type => "tinyint", is_nullable => 1 },
   "remove_minors",
   { data_type => "tinyint", is_nullable => 1 },
-  "require_lost",
-  { data_type => "tinyint", is_nullable => 1 },
   "unique_email",
   { data_type => "varchar", is_nullable => 1, size => 191 },
   "additional_email",
@@ -259,7 +257,7 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "config_type",
   { data_type => "varchar", is_nullable => 0, size => 15 },
-  "debit_type",
+  "config_debit_type",
   { data_type => "varchar", is_nullable => 0, size => 191 },
   "require_lost",
   { data_type => "tinyint", is_nullable => 0 },

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
@@ -226,7 +226,7 @@
                                             "type": "string",
                                             "description": "Does the patron need to have a lost fee to be sent to collections"
                                         },
-                                        "debit_type": {
+                                        "config_debit_type": {
                                             "type": [
                                                 "string",
                                                 "null"
@@ -498,7 +498,7 @@
                     "type": "string",
                     "description": "What type of config is it"
                 },
-                "debit_type": {
+                "config_debit_type": {
                     "type": [
                         "string",
                         "null"

--- a/t/db_dependent/api.t
+++ b/t/db_dependent/api.t
@@ -99,7 +99,7 @@ subtest 'add() tests' => sub {
         enabled      => 1,
         threshold    => "25",
         day_of_week  => "1",
-        debit_type   => 'manual',
+        config_debit_type   => 'manual',
         require_lost => "0",
     };
 
@@ -155,7 +155,7 @@ subtest 'add() duplicate detection tests' => sub {
         config_type  => 'library',
         branch       => $library->branchcode,
         enabled      => 1,
-        debit_type   => 'manual',
+        config_debit_type   => 'manual',
         require_lost => "0",
     };
 


### PR DESCRIPTION
## Summary

The DBIC Schema Result declared `debit_type` but the actual DB column is `config_debit_type`. This caused TestBuilder to generate INSERT statements with a non-existent column, failing all CI tests with:

```
Unknown column 'debit_type' in 'INSERT INTO'
```

## Changes

- **Schema Result**: rename column to `config_debit_type`, remove duplicate `require_lost` entry
- **OpenAPI spec**: use `config_debit_type` field name
- **JS (configure.js)**: use `config_debit_type` in read/write
- **Tests**: use `config_debit_type` in request bodies

## Testing

CI should pass once this is merged.

Closes #22