### PR TITLE
[#23] Normalize debit_types and patron_categories into join tables

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge.pm
@@ -61,10 +61,16 @@ BEGIN {
     unshift @INC, $path;
 
     require Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfig;
+    require Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType;
+    require Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory;
 
     #register the additional schema classes
     Koha::Schema->register_class( KohaPluginComBywatersolutionsUmsgentlenudgeConfig =>
             'Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfig' );
+    Koha::Schema->register_class( KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType =>
+            'Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType' );
+    Koha::Schema->register_class( KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory =>
+            'Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory' );
 
     # force a refresh of the database handle so that it includes the new classes
     Koha::Database->schema( { new => 1 } );
@@ -840,9 +846,7 @@ sub install() {
                     config_name VARCHAR(100) NULL COMMENT 'Name of the group or library',
                     branch VARCHAR(10) NULL COMMENT 'Selected branch',
                     config_group int(11) NULL COMMENT 'Selected group',
-                    debit_types VARCHAR(191) NULL COMMENT 'JSON array of debit types to be used for collections. Only selected types will be counted for total.',
                     day_of_week int(1)  NULL COMMENT 'Which day of the week should the report run on',
-                    patron_categories VARCHAR(191) NULL COMMENT 'JSON array of patron category codes that are eligible for collections. e.g. CAT1,CAT2,CAT3. Leave blank for all categories.',
                     threshold int(11) NULL COMMENT 'Minimum amount owed to be sent to collections.',
                     processing_fee int(11) NULL COMMENT 'Amount of the processing fee added to the patron account',
                     collections_flag VARCHAR(191) NULL COMMENT 'Specify how the patron is flagged as being in collections. If using a patron attribute, it is recommended that the attribute be mapped to the YES_NO category.',
@@ -877,6 +881,28 @@ sub install() {
     $dbh->do(
         "INSERT IGNORE INTO $configuration (config_name, config_type, day_of_week, threshold, config_debit_type, require_lost, remove_minors, fees_newer, fees_older, remove_restriction, restriction) VALUES ('Global', 'global', 0, '10', 'manual', 0, 0, '90', '60', 0, 0)"
     );    #Create default configuration
+
+    my $config_debit_type = $self->get_qualified_table_name('config_dt');
+    $dbh->do("
+        CREATE TABLE IF NOT EXISTS $config_debit_type (
+            config_id int(11) NOT NULL,
+            debit_type_code VARCHAR(64) NOT NULL,
+            PRIMARY KEY (config_id, debit_type_code),
+            CONSTRAINT config_dt_cfg_fk FOREIGN KEY (config_id) REFERENCES $configuration (config_id) ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT config_dt_code_fk FOREIGN KEY (debit_type_code) REFERENCES account_debit_types (code) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ");
+
+    my $config_patron_category = $self->get_qualified_table_name('config_pc');
+    $dbh->do("
+        CREATE TABLE IF NOT EXISTS $config_patron_category (
+            config_id int(11) NOT NULL,
+            category_code VARCHAR(10) NOT NULL,
+            PRIMARY KEY (config_id, category_code),
+            CONSTRAINT config_pc_cfg_fk FOREIGN KEY (config_id) REFERENCES $configuration (config_id) ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT config_pc_code_fk FOREIGN KEY (category_code) REFERENCES categories (categorycode) ON DELETE CASCADE ON UPDATE CASCADE
+        ) ENGINE=INNODB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ");
 
     my $default_config = $dbh->selectcol_arrayref("SELECT config_id FROM $configuration");
     return 1;

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/ConfigController.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/ConfigController.pm
@@ -6,7 +6,6 @@ use Mojo::Base 'Mojolicious::Controller';
 use Koha::Plugin::Com::ByWaterSolutions::UMSGentleNudge;
 use Koha::Libraries;
 use Koha::Library::Groups;
-use JSON qw( encode_json );
 
 my $plugin = Koha::Plugin::Com::ByWaterSolutions::UMSGentleNudge->new;
 
@@ -97,11 +96,16 @@ sub add {
     }
 
     return try {
-        $body->{patron_categories} = encode_json( $body->{patron_categories} )
-            if $body->{patron_categories};
-        $body->{debit_types} = encode_json( $body->{debit_types} )
-            if $body->{debit_types};
+        my $patron_category_codes = delete $body->{patron_category_codes} // delete $body->{patron_categories};
+        my $debit_type_codes      = delete $body->{debit_type_codes};
+
+        # Legacy: accept debit_type as alias for config_debit_type
+        $body->{config_debit_type} //= delete $body->{debit_type} if exists $body->{debit_type};
+
         my $config = $plugin->configs->object_class->new_from_api($body)->store;
+        $config->set_debit_types($debit_type_codes);
+        $config->set_patron_categories($patron_category_codes);
+
         $c->res->headers->location( $c->req->url->to_string . '/' . $config->config_id );
 
         #logaction( 'SYSTEMPREFERENCE', 'ADD', $config->config_id, $config );
@@ -143,11 +147,16 @@ sub update {
     }
 
     return try {
-        $body->{patron_categories} = encode_json( $body->{patron_categories} )
-            if $body->{patron_categories};
-        $body->{debit_types} = encode_json( $body->{debit_types} )
-            if $body->{debit_types};
+        my $patron_category_codes = delete $body->{patron_category_codes} // delete $body->{patron_categories};
+        my $debit_type_codes      = delete $body->{debit_type_codes};
+
+        # Legacy: accept debit_type as alias for config_debit_type
+        $body->{config_debit_type} //= delete $body->{debit_type} if exists $body->{debit_type};
+
         $config->set_from_api($body)->store;
+        $config->set_debit_types($debit_type_codes)       if $debit_type_codes;
+        $config->set_patron_categories($patron_category_codes) if $patron_category_codes;
+
         $c->res->headers->location( $c->req->url->to_string );
 
         # logaction(

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
@@ -63,6 +63,7 @@
                 $.ajax({
                     url: '/api/v1/contrib/ums/config/' + event.relatedTarget.getAttribute('data-config-id'),
                     method: 'GET',
+                    headers: { 'x-koha-embed': 'debit_types,patron_categories' },
                     success: function(config) {
 
                         if (config.config_type == "library") {
@@ -85,7 +86,7 @@
                         document.getElementById("fees_starting_age").value = config.fees_newer;
                         document.getElementById("fees_ending_age").value = config.fees_older;
                         document.getElementById("fees_created_before_date_filter").value = config.ignore_before;
-                        document.getElementById("umsconfig_categories").value = config.patron_categories;
+                        document.getElementById("umsconfig_categories").value = (config.patron_categories || []).map(c => c.categorycode).join(',');
                         document.getElementById("processing_fee").value = config.processing_fee;
                         document.getElementById("age_limitation").value = config.remove_minors;
                         document.getElementById("add_restriction").value = config.restriction;
@@ -351,7 +352,7 @@
                     fees_newer: $('#fees_starting_age').val(),
                     fees_older: $('#fees_ending_age').val(),
                     ignore_before: $('#fees_created_before_date_filter').val(),
-                    //patron_categories: $('#umsconfig_categories').val(),
+                    patron_category_codes: $('#umsconfig_categories').val() ? $('#umsconfig_categories').val().split(',').filter(Boolean) : [],
                     processing_fee: $('#processing_fee').val(),
                     remove_minors: $('#age_limitation').val(),
                     remove_restriction:$('#remove_restriction').val(),

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/js/configure.js
@@ -78,7 +78,7 @@
                         document.getElementById("clear_below").value = config.clear_below;
                         document.getElementById("clear_threshold").value = config.clear_threshold;
                         document.getElementById("collections_flag").value = config.collections_flag;
-                        document.getElementById("processing_debit").value = config.debit_type;
+                        document.getElementById("processing_debit").value = config.config_debit_type;
                         document.getElementById("run_on_dow").value = config.day_of_week;
                         document.getElementById("config-enabled").value = config.enabled;
                         document.getElementById("exemption_flag").value = config.exemptions_flag;
@@ -345,7 +345,7 @@
                     config_name: $('#config_name').val(),
                     config_type: configtype,
                     day_of_week: $('#run_on_dow').val(),
-                    debit_type: debit_type,
+                    config_debit_type: debit_type,
                     enabled: $('#config-enabled').val(),
                     exemptions_flag: $('#exemption_flag').val(),
                     fees_newer: $('#fees_starting_age').val(),

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
@@ -197,7 +197,7 @@ If there is a default configuration, all branches/groups will be included. 0=dis
 
 Options are global (can only have 1 global), branch, or group
 
-=head2 debit_type
+=head2 config_debit_type
 
   data_type: 'varchar'
   is_nullable: 0
@@ -249,8 +249,6 @@ __PACKAGE__->add_columns(
   { data_type => "tinyint", is_nullable => 1 },
   "remove_minors",
   { data_type => "tinyint", is_nullable => 1 },
-  "require_lost",
-  { data_type => "tinyint", is_nullable => 1 },
   "unique_email",
   { data_type => "varchar", is_nullable => 1, size => 191 },
   "additional_email",
@@ -259,7 +257,7 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "config_type",
   { data_type => "varchar", is_nullable => 0, size => 15 },
-  "debit_type",
+  "config_debit_type",
   { data_type => "varchar", is_nullable => 0, size => 191 },
   "require_lost",
   { data_type => "tinyint", is_nullable => 0 },

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfig.pm
@@ -71,14 +71,6 @@ Selected group
 
 Which day of the week
 
-=head2 patron_categories
-
-  data_type: 'varchar'
-  is_nullable: 1
-  size: 191
-
-Comma delimited list of patron category codes that are eligible for collections. e.g. CAT1,CAT2,CAT3. Leave blank for all categories.
-
 =head2 threshold
 
   data_type: 'integer'
@@ -223,8 +215,6 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "day_of_week",
   { data_type => "integer", is_nullable => 1 },
-  "patron_categories",
-  { data_type => "varchar", is_nullable => 1, size => 191 },
   "threshold",
   { data_type => "integer", is_nullable => 1 },
   "processing_fee",
@@ -323,4 +313,19 @@ __PACKAGE__->belongs_to(
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
+
+__PACKAGE__->has_many(
+  "config_debit_types",
+  "Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType",
+  { "foreign.config_id" => "self.config_id" },
+  { cascade_copy => 0, cascade_delete => 1 },
+);
+
+__PACKAGE__->has_many(
+  "config_patron_categories",
+  "Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory",
+  { "foreign.config_id" => "self.config_id" },
+  { cascade_copy => 0, cascade_delete => 1 },
+);
+
 1;

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType.pm
@@ -1,0 +1,34 @@
+use utf8;
+package Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigDebitType;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table("koha_plugin_com_bywatersolutions_umsgentlenudge_config_dt");
+
+__PACKAGE__->add_columns(
+  "config_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "debit_type_code",
+  { data_type => "varchar", is_foreign_key => 1, is_nullable => 0, size => 64 },
+);
+
+__PACKAGE__->set_primary_key("config_id", "debit_type_code");
+
+__PACKAGE__->belongs_to(
+  "config",
+  "Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfig",
+  { config_id => "config_id" },
+  { on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+__PACKAGE__->belongs_to(
+  "debit_type",
+  "Koha::Schema::Result::AccountDebitType",
+  { code => "debit_type_code" },
+  { on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+1;

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/Koha/Schema/Result/KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory.pm
@@ -1,0 +1,34 @@
+use utf8;
+package Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfigPatronCategory;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table("koha_plugin_com_bywatersolutions_umsgentlenudge_config_pc");
+
+__PACKAGE__->add_columns(
+  "config_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "category_code",
+  { data_type => "varchar", is_foreign_key => 1, is_nullable => 0, size => 10 },
+);
+
+__PACKAGE__->set_primary_key("config_id", "category_code");
+
+__PACKAGE__->belongs_to(
+  "config",
+  "Koha::Schema::Result::KohaPluginComBywatersolutionsUmsgentlenudgeConfig",
+  { config_id => "config_id" },
+  { on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+__PACKAGE__->belongs_to(
+  "patron_category",
+  "Koha::Schema::Result::Category",
+  { categorycode => "category_code" },
+  { on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+1;

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/UMS/GentleNudge/Config.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/UMS/GentleNudge/Config.pm
@@ -4,8 +4,9 @@ use Modern::Perl;
 use C4::Context;
 use Koha::Database;
 use Koha::Library::Group;
+use Koha::Account::DebitTypes;
+use Koha::Patron::Categories;
 use base qw(Koha::Object);
-use JSON qw( encode_json decode_json );
 
 =head1 NAME
 
@@ -15,12 +16,81 @@ UMS::GentleNudge::Config - UMS Configuration Object class
 
 =head2 Class methods
 
+=head3 debit_types
+
+Returns the linked Koha::Account::DebitTypes resultset
+
 =cut
 
-sub to_api {
-    my ( $self, $params ) = @_;
-    my $json;
-    my %json;
+sub debit_types {
+    my ($self) = @_;
+
+    my @codes = $self->_result->config_debit_types->get_column('debit_type_code')->all;
+    return Koha::Account::DebitTypes->new->empty unless @codes;
+    return Koha::Account::DebitTypes->search( { code => { -in => \@codes } } );
+}
+
+=head3 add_debit_type
+
+    $config->add_debit_type($code);
+
+=cut
+
+sub add_debit_type {
+    my ( $self, $code ) = @_;
+    $self->_result->add_to_config_debit_types( { debit_type_code => $code } );
+    return $self;
+}
+
+=head3 set_debit_types
+
+    $config->set_debit_types(\@codes);
+
+=cut
+
+sub set_debit_types {
+    my ( $self, $codes ) = @_;
+    $self->_result->config_debit_types->delete;
+    $self->add_debit_type($_) for @{ $codes // [] };
+    return $self;
+}
+
+=head3 patron_categories
+
+Returns the linked Koha::Patron::Categories resultset
+
+=cut
+
+sub patron_categories {
+    my ($self) = @_;
+
+    my @codes = $self->_result->config_patron_categories->get_column('category_code')->all;
+    return Koha::Patron::Categories->new->empty unless @codes;
+    return Koha::Patron::Categories->search( { categorycode => { -in => \@codes } } );
+}
+
+=head3 add_patron_category
+
+    $config->add_patron_category($code);
+
+=cut
+
+sub add_patron_category {
+    my ( $self, $code ) = @_;
+    $self->_result->add_to_config_patron_categories( { category_code => $code } );
+    return $self;
+}
+
+=head3 set_patron_categories
+
+    $config->set_patron_categories(\@codes);
+
+=cut
+
+sub set_patron_categories {
+    my ( $self, $codes ) = @_;
+    $self->_result->config_patron_categories->delete;
+    $self->add_patron_category($_) for @{ $codes // [] };
     return $self;
 }
 

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
@@ -226,7 +226,7 @@
                                             "type": "string",
                                             "description": "Does the patron need to have a lost fee to be sent to collections"
                                         },
-                                        "debit_type": {
+                                        "config_debit_type": {
                                             "type": [
                                                 "string",
                                                 "null"
@@ -498,7 +498,7 @@
                     "type": "string",
                     "description": "What type of config is it"
                 },
-                "debit_type": {
+                "config_debit_type": {
                     "type": [
                         "string",
                         "null"

--- a/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
+++ b/Koha/Plugin/Com/ByWaterSolutions/UMSGentleNudge/lib/api/openapi.json
@@ -12,6 +12,18 @@
             ],
             "parameters": [
                 {
+                    "name": "x-koha-embed",
+                    "in": "header",
+                    "required": false,
+                    "description": "Embed list sent as a request header",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["debit_types", "patron_categories"]
+                    },
+                    "collectionFormat": "csv"
+                },
+                {
                     "description": "Matching criteria",
                     "enum": [
                         "contains",
@@ -118,13 +130,6 @@
                                                 "null"
                                             ],
                                             "description": "Day of week to run"
-                                        },
-                                        "patron_categories": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ],
-                                            "description": "Patron categories to include"
                                         },
                                         "threshold": {
                                             "type": [
@@ -333,6 +338,14 @@
         "application/json"
       ],
       "parameters": [{
+          "name": "x-koha-embed",
+          "in": "header",
+          "required": false,
+          "description": "Embed list sent as a request header",
+          "type": "array",
+          "items": { "type": "string", "enum": ["debit_types", "patron_categories"] },
+          "collectionFormat": "csv"
+        },{
           "name": "config_id",
           "in": "path",
           "description": "Search on config id",
@@ -360,6 +373,14 @@
         "application/json"
       ],
       "parameters": [{
+          "name": "x-koha-embed",
+          "in": "header",
+          "required": false,
+          "description": "Embed list sent as a request header",
+          "type": "array",
+          "items": { "type": "string", "enum": ["debit_types", "patron_categories"] },
+          "collectionFormat": "csv"
+        },{
           "name": "config_id",
           "in": "path",
           "description": "Search on config id",
@@ -391,12 +412,21 @@
                     ],
                     "description": "Day of week to run"
                 },
-                "patron_categories": {
+                "patron_category_codes": {
                     "type": [
                         "array",
                         "null"
                     ],
-                    "description": "Email from unique"
+                    "items": { "type": "string" },
+                    "description": "Patron category codes eligible for collections"
+                },
+                "debit_type_codes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": { "type": "string" },
+                    "description": "Debit type codes to count for collections"
                 },
                 "require_lost": {
                     "type": "string",

--- a/t/db_dependent/api.t
+++ b/t/db_dependent/api.t
@@ -99,7 +99,7 @@ subtest 'add() tests' => sub {
         enabled      => 1,
         threshold    => "25",
         day_of_week  => "1",
-        debit_type   => 'manual',
+        config_debit_type   => 'manual',
         require_lost => "0",
     };
 
@@ -155,7 +155,7 @@ subtest 'add() duplicate detection tests' => sub {
         config_type  => 'library',
         branch       => $library->branchcode,
         enabled      => 1,
-        debit_type   => 'manual',
+        config_debit_type   => 'manual',
         require_lost => "0",
     };
 


### PR DESCRIPTION
## Summary

Replaces the JSON-encoded VARCHAR columns (`debit_types`, `patron_categories`) with proper join tables.

## Changes

- New tables: `..._config_dt` and `..._config_pc` (shortened for MySQL 64-char limit)
- Schema Result: removed `patron_categories` column, added `has_many` relationships
- ConfigController: uses relationships instead of `encode_json`
- OpenAPI spec: `debit_types` and `patron_categories` defined as proper arrays
- Install method: creates the new tables

## Testing

`prove t/db_dependent/api.t` — all 5 tests pass on KTD.

Closes #23